### PR TITLE
French locale added

### DIFF
--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -19,7 +19,7 @@
 # To learn more, please read the Rails Internationalization guide
 # available at http://guides.rubyonrails.org/i18n.html.
 
-en:
+fr:
   navigation:
     brand: "# Inch CI"
     home: Accueil
@@ -43,9 +43,9 @@ en:
     project_placeholder: https://github.com/rrrene/inch
     add_project: "Ajouter un projet"
   about:
-    headline: "Qu’est-ce que Inch CI?"
+    headline: "Qu’est-ce que Inch CI ?"
     abstract: |
-      Ce project est une tentative pour augmenter la visibilité de la documentation de code en Ruby. Il fournit des badges à inclure dans vos README, pour montrer à tout le monde que la documentation de code est un truc cool.
+      Ce project est une tentative pour augmenter la visibilité de la documentation de code en Ruby. Il fournit des badges à inclure dans vos READMEs, pour montrer à tout le monde que la documentation de code est un truc cool.
 
       Les badges sont basés sur Inch et ressemblent à ça :
       ![Documentation de code](%{badge_image_url})


### PR DESCRIPTION
I noticed you had a `config/locales/en.yml` file, so since I’m a native French speaker I added a French locale. Please note this is the first time I write an i18n file for a Rails app.

Some strings are missing from this file, and thus a few parts of the website are still in English.

Here are a couple notes on this translation :
- I voluntarily used English words for hard-to-translate concepts. For example, there’s no French word to describe what a webhook is, and most people use the word “README” in French instead of our equivalent, “LISEZMOI”.
- I used the word “évaluation” for “build”, because what you mean by “builds” is “documentation evaluations/tests” and there’s no really good French word for “build”.
- I didn’t understand the purpose of the line “Let's start a discussion, let's raise the visibility of documentation, let's talk.” Do you want to discuss _and_ talk? I translated this to something that roughly say “Let’s discuss, let’s raise the visibility of documentation”
- I translated both “inline documentation” and “code documentation” with the same “documentation de code”, because I don’t know any equivalent of “inline documentation” in French that doesn’t sound weird.
- A couple strings could be improved with more info, for example `shared.code_object_roles.object.without_doc` needs an article before `%{object_type}` but it depends on the word used for `object_type`.
