### PR TITLE
Introduce and re-use `assert_badge`

### DIFF
--- a/test/inch_ci/badge_test.rb
+++ b/test/inch_ci/badge_test.rb
@@ -11,11 +11,6 @@ describe ::InchCI::Badge do
     counts = [0,1,2,3]
     described_class.create(project, branch, counts)
     base = File.join(Rails.root, "tmp", "github", "rrrene", "sparkr")
-    %w(png svg).each do |image_format|
-      %w(default flat).each do |style|
-        file = File.join(base, "master.#{style}.#{image_format}")
-        assert File.exist?(file)
-      end
-    end
+    assert_badge(base)
   end
 end

--- a/test/inch_ci/worker/project/build/generate_badge_test.rb
+++ b/test/inch_ci/worker/project/build/generate_badge_test.rb
@@ -11,11 +11,6 @@ describe ::InchCI::Worker::Project::Build::GenerateBadge do
     code_objects = branch.latest_revision.code_objects
     described_class.new(project, branch, code_objects)
     base = File.join(Rails.root, "tmp", "github", "rrrene", "sparkr")
-    %w(png svg).each do |image_format|
-      %w(default flat).each do |style|
-        file = File.join(base, "master.#{style}.#{image_format}")
-        assert File.exist?(file)
-      end
-    end
+    assert_badge(base)
   end
 end

--- a/test/support/mini_test_spec.rb
+++ b/test/support/mini_test_spec.rb
@@ -27,4 +27,11 @@ class MiniTest::Spec
       assert(e.call - before[i] > 0, error)
     end
   end
+
+  def assert_badge(base)
+    InchCI::Badge.each_image_combination do |format, style|
+      file = File.join(base, "master.#{style}.#{format}")
+      assert File.exist?(file), "File #{file} not found"
+    end
+  end
 end


### PR DESCRIPTION
There is some duplication asserting correct badge generation so I introduced `assert_badge` to DRY things up.

@rrrene WDYT?
