### PR TITLE
Make stats-box responsive for project pages

### DIFF
--- a/app/views/projects/_stats.html.haml
+++ b/app/views/projects/_stats.html.haml
@@ -6,26 +6,27 @@
       .progress-bar.progress-bar-C{:"data-placement" => 'bottom', :"data-toggle" => 'tooltip', :style => "width: #{@collection.percent('C')}%", :title => t('grade_list_table.header_C')}
       .progress-bar.progress-bar-U{:"data-placement" => 'bottom', :"data-toggle" => 'tooltip', :style => "width: #{@collection.percent('U')}%", :title => t('grade_list_table.header_U')}
 
-    %table.table.stats-box
-      %tr
-        %th.build_number
-          = t('projects.topbar.info.build_number')
-        %td.build_number
-          - if @revision && @build = @revision.builds.last
-            = "##{@build.number}"
-            %small
-              = link_to_build_history(@project)
-        %th.revision_uid
-          = t('projects.topbar.info.revision_uid')
-        %td.revision_uid
-          = @revision.uid
-        - if @project.source_code_url
-          %th.source_code_url
-            = t('projects.topbar.info.source_code_url')
-          %td.source_code_url
-            = link_to_with_hostname @project.source_code_url, :target => '_blank'
-        - if @project.documentation_url
-          %th.documentation_url
-            = t('projects.topbar.info.documentation_url')
-          %td.documentation_url
-            = link_to_with_hostname @project.documentation_url, :target => '_blank'
+    .table-responsive
+      %table.table.stats-box
+        %tr
+          %th.build_number
+            = t('projects.topbar.info.build_number')
+          %td.build_number
+            - if @revision && @build = @revision.builds.last
+              = "##{@build.number}"
+              %small
+                = link_to_build_history(@project)
+          %th.revision_uid
+            = t('projects.topbar.info.revision_uid')
+          %td.revision_uid
+            = @revision.uid
+          - if @project.source_code_url
+            %th.source_code_url
+              = t('projects.topbar.info.source_code_url')
+            %td.source_code_url
+              = link_to_with_hostname @project.source_code_url, :target => '_blank'
+          - if @project.documentation_url
+            %th.documentation_url
+              = t('projects.topbar.info.documentation_url')
+            %td.documentation_url
+              = link_to_with_hostname @project.documentation_url, :target => '_blank'


### PR DESCRIPTION
At the moment the `table.stats-box` on the project page isn't responsive and breaks the layout on smaller devices. This PR wraps the box into a `.table-responsive` as other tables are already handled.

Before:
![img_0282](https://cloud.githubusercontent.com/assets/678542/5761333/0ea7f4c4-9cdb-11e4-9a21-8ced3757a642.PNG)

After:
![img_0283](https://cloud.githubusercontent.com/assets/678542/5761338/12fb7a3c-9cdb-11e4-9099-6fdfbd0d8f4b.PNG)
