### PR TITLE
minor typo in elixir deps section

### DIFF
--- a/app/views/shared/_how_to_travis_elixir.html.haml
+++ b/app/views/shared/_how_to_travis_elixir.html.haml
@@ -12,7 +12,7 @@
   To add your project to Inch CI, you have to include `inch_ex` in your dependencies in the `mix.exs` file:
 
       defp deps do
-        [{:inch_ex, only: docs}]
+        [{:inch_ex, only: :docs}]
       end
 
   Your `.travis.yml` might look something like this:


### PR DESCRIPTION
In a mix project's `deps/0`, the environment is supposed to be an atom?