### PR TITLE
Pass https as protocol to URL helpers to prevent JS being blocked by …

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -8,4 +8,4 @@
 
 - if can_edit? && @user.last_synced_projects_at.nil?
   :javascript
-    I.user.syncProjects(#{sync_projects_url.to_json});
+    I.user.syncProjects(#{sync_projects_url(protocol: 'https').to_json});

--- a/app/views/users/welcome.html.haml
+++ b/app/views/users/welcome.html.haml
@@ -48,7 +48,7 @@
         %small
           Syncing projects. This may take 10-30 seconds, if you have many.
       :javascript
-        I.user.syncProjects(#{init_projects_url.to_json});
+        I.user.syncProjects(#{init_projects_url(protocol: 'https').to_json});
 
     %p#synced{:style => start_sync ? 'display:none' : nil}
       = link_to(("Let's look at my projects" + ' ' + icon(:'arrow-right')).html_safe, user_path(current_user), :class => 'btn btn-lg btn-default')


### PR DESCRIPTION
…browser as insecure.

Currently new users are seeing a message to wait for their Github projects to sync indefinitely. This is due to the browser blocking the ajax request on security grounds.